### PR TITLE
Add `import` statements

### DIFF
--- a/StepLang.Tests/Examples/imports.step.out
+++ b/StepLang.Tests/Examples/imports.step.out
@@ -1,5 +1,7 @@
-3
-2
-1
-2
-Imported from scoped.step: a = 1
+(in scope) a = 3
+(in scope) b = 2
+a = 1
+b = 2
+Imported scoped.step
+a = 1
+b = 2

--- a/StepLang.Tests/Examples/imports.step.out
+++ b/StepLang.Tests/Examples/imports.step.out
@@ -1,0 +1,5 @@
+3
+2
+1
+2
+Imported from scoped.step: a = 1

--- a/StepLang.Tests/Examples/scoped.step.out
+++ b/StepLang.Tests/Examples/scoped.step.out
@@ -1,4 +1,4 @@
-3
-2
-1
-2
+(in scope) a = 3
+(in scope) b = 2
+a = 1
+b = 2

--- a/StepLang/Examples/imports.step
+++ b/StepLang/Examples/imports.step
@@ -1,3 +1,5 @@
-import "Examples/scoped.step"
+import "scoped.step"
 
-println("Imported from scoped.step: a = ", a)
+println("Imported scoped.step")
+println("a = ", a)
+println("b = ", b)

--- a/StepLang/Examples/imports.step
+++ b/StepLang/Examples/imports.step
@@ -1,0 +1,3 @@
+import "Examples/scoped.step"
+
+println("Imported from scoped.step: a = ", a)

--- a/StepLang/Examples/scoped.step
+++ b/StepLang/Examples/scoped.step
@@ -4,9 +4,9 @@ number b = 2
 {
     number a = 3
 
-    print(a, EOL)
-    print(b, EOL)
+    println("(in scope) a = ", a)
+    println("(in scope) b = ", b)
 }
 
-print(a, EOL)
-print(b, EOL)
+println("a = ", a)
+println("b = ", b)

--- a/StepLang/Parsing/Statements/ImportStatement.cs
+++ b/StepLang/Parsing/Statements/ImportStatement.cs
@@ -1,0 +1,38 @@
+using StepLang.Interpreting;
+using StepLang.Tokenizing;
+
+namespace StepLang.Parsing.Statements;
+
+internal class ImportStatement : Statement
+{
+    private readonly Token filePathToken;
+
+    public ImportStatement(Token filePathToken) : base(StatementType.ImportStatement)
+    {
+        if (filePathToken.Type is not TokenType.LiteralString)
+            throw new UnexpectedTokenException(filePathToken, TokenType.LiteralString);
+
+        this.filePathToken = filePathToken;
+    }
+
+    /// <inheritdoc />
+    public override async Task ExecuteAsync(Interpreter interpreter, CancellationToken cancellationToken = default)
+    {
+        var fileInfo = new FileInfo(filePathToken.Value);
+
+        if (!fileInfo.Exists)
+            throw new ImportedFileDoesNotExistException(fileInfo);
+
+        var fileContents = await File.ReadAllTextAsync(fileInfo.FullName, cancellationToken);
+
+        var tokenizer = new Tokenizer();
+        tokenizer.Add(fileContents);
+        var tokens = tokenizer.TokenizeAsync(cancellationToken);
+
+        var parser = new StatementParser();
+        parser.Add(tokens);
+        var statements = parser.ParseAsync(cancellationToken);
+
+        await interpreter.InterpretAsync(statements, cancellationToken);
+    }
+}

--- a/StepLang/Parsing/Statements/ImportStatement.cs
+++ b/StepLang/Parsing/Statements/ImportStatement.cs
@@ -5,14 +5,19 @@ namespace StepLang.Parsing.Statements;
 
 internal sealed class ImportStatement : Statement
 {
+    private readonly Token importToken;
     private readonly Token filePathToken;
 
-    public ImportStatement(Token filePathToken) : base(StatementType.ImportStatement)
+    public ImportStatement(Token importToken, Token filePathToken) : base(StatementType.ImportStatement)
     {
+        this.importToken = importToken;
+
         if (filePathToken.Type is not TokenType.LiteralString)
             throw new UnexpectedTokenException(filePathToken, TokenType.LiteralString);
 
         this.filePathToken = filePathToken;
+
+        Location = importToken.Location;
     }
 
     /// <inheritdoc />

--- a/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+using StepLang.Interpreting;
+
+namespace StepLang.Parsing.Statements;
+
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
+internal class ImportedFileDoesNotExistException : InterpreterException
+{
+    public ImportedFileDoesNotExistException(FileSystemInfo fileInfo) : base("Imported file does not exist: " + fileInfo.FullName)
+    {
+    }
+}

--- a/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
@@ -1,12 +1,13 @@
 using System.Diagnostics.CodeAnalysis;
 using StepLang.Interpreting;
+using StepLang.Tokenizing;
 
 namespace StepLang.Parsing.Statements;
 
 [SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
-internal class ImportedFileDoesNotExistException : InterpreterException
+internal sealed class ImportedFileDoesNotExistException : InterpreterException
 {
-    public ImportedFileDoesNotExistException(FileSystemInfo fileInfo) : base("Imported file does not exist: " + fileInfo.FullName)
+    public ImportedFileDoesNotExistException(TokenLocation? importTokenLocation, FileSystemInfo fileInfo) : base(importTokenLocation, "Imported file does not exist: " + fileInfo.FullName)
     {
     }
 }

--- a/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileDoesNotExistException.cs
@@ -4,10 +4,9 @@ using StepLang.Tokenizing;
 
 namespace StepLang.Parsing.Statements;
 
-[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
 internal sealed class ImportedFileDoesNotExistException : InterpreterException
 {
-    public ImportedFileDoesNotExistException(TokenLocation? importTokenLocation, FileSystemInfo fileInfo) : base(importTokenLocation, "Imported file does not exist: " + fileInfo.FullName)
+    public ImportedFileDoesNotExistException(TokenLocation? importTokenLocation, FileSystemInfo fileInfo) : base(importTokenLocation, "Imported file does not exist: " + fileInfo.FullName, "Check the path of the imported file. If the path is absolute, make sure it is correct. If the path is relative, make sure it is relative to the file that is importing it.")
     {
     }
 }

--- a/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
@@ -4,7 +4,7 @@ using StepLang.Tokenizing;
 
 namespace StepLang.Parsing.Statements;
 
-internal class ImportedFileIsSelfException : InterpreterException
+internal sealed class ImportedFileIsSelfException : InterpreterException
 {
     public ImportedFileIsSelfException(TokenLocation location, FileSystemInfo fileInfo) : base(location, "Imported file imports itself: " + fileInfo.FullName, "Files cannot import themselves as this would cause an infinite loop. If you didn't intend to import this file, check the path of the imported file.")
     {

--- a/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
@@ -4,10 +4,9 @@ using StepLang.Tokenizing;
 
 namespace StepLang.Parsing.Statements;
 
-[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
 internal class ImportedFileIsSelfException : InterpreterException
 {
-    public ImportedFileIsSelfException(TokenLocation location, FileSystemInfo fileInfo) : base(location, "Imported file imports itself: " + fileInfo.FullName)
+    public ImportedFileIsSelfException(TokenLocation location, FileSystemInfo fileInfo) : base(location, "Imported file imports itself: " + fileInfo.FullName, "Files cannot import themselves as this would cause an infinite loop. If you didn't intend to import this file, check the path of the imported file.")
     {
     }
 }

--- a/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
+++ b/StepLang/Parsing/Statements/ImportedFileIsSelfException.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+using StepLang.Interpreting;
+using StepLang.Tokenizing;
+
+namespace StepLang.Parsing.Statements;
+
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
+internal class ImportedFileIsSelfException : InterpreterException
+{
+    public ImportedFileIsSelfException(TokenLocation location, FileSystemInfo fileInfo) : base(location, "Imported file imports itself: " + fileInfo.FullName)
+    {
+    }
+}

--- a/StepLang/Parsing/Statements/ImportsNoLongerAllowedException.cs
+++ b/StepLang/Parsing/Statements/ImportsNoLongerAllowedException.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+using StepLang.Tokenizing;
+
+namespace StepLang.Parsing.Statements;
+
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
+public class ImportsNoLongerAllowedException : ParserException
+{
+    public ImportsNoLongerAllowedException(Token token) : base(token, "Imports are only allowed before the first statement")
+    {
+    }
+}

--- a/StepLang/Parsing/Statements/ImportsNoLongerAllowedException.cs
+++ b/StepLang/Parsing/Statements/ImportsNoLongerAllowedException.cs
@@ -3,10 +3,9 @@ using StepLang.Tokenizing;
 
 namespace StepLang.Parsing.Statements;
 
-[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
 public class ImportsNoLongerAllowedException : ParserException
 {
-    public ImportsNoLongerAllowedException(Token token) : base(token, "Imports are only allowed before the first statement")
+    public ImportsNoLongerAllowedException(Token token) : base(token, "Import statement used after first statement", "Imports are only allowed before the first statement. You can use as many as you want, but as soon as any other statement is used, no more imports are allowed.")
     {
     }
 }

--- a/StepLang/Parsing/Statements/StatementParser.cs
+++ b/StepLang/Parsing/Statements/StatementParser.cs
@@ -27,7 +27,9 @@ public class StatementParser
 
             var type = token.Type;
 
-            if (type is TokenType.TypeName)
+            if (type is TokenType.ImportKeyword)
+                yield return await ParseImportStatement(cancellationToken);
+            else if (type is TokenType.TypeName)
                 yield return await ParseVariableDeclaration(token, cancellationToken);
             else if (type is TokenType.Identifier or TokenType.UnderscoreSymbol)
                 yield return await ParseIdentifierUsage(token, cancellationToken);
@@ -48,6 +50,15 @@ public class StatementParser
             else if (type is not TokenType.Whitespace and not TokenType.NewLine and not TokenType.LineComment)
                 throw new UnexpectedTokenException(token, TokenType.TypeName, TokenType.Identifier, TokenType.UnderscoreSymbol, TokenType.Whitespace, TokenType.NewLine, TokenType.LineComment, TokenType.IfKeyword, TokenType.WhileKeyword, TokenType.ReturnKeyword, TokenType.OpeningCurlyBracket, TokenType.ClosingCurlyBracket);
         }
+    }
+
+    private Task<Statement> ParseImportStatement(CancellationToken cancellationToken = default)
+    {
+        // import: import <literal string>
+
+        var literalStringToken = tokenQueue.Dequeue(TokenType.LiteralString);
+
+        return Task.FromResult<Statement>(new ImportStatement(literalStringToken));
     }
 
     private async Task<Statement> ParseContinueStatement(Token continueToken, CancellationToken cancellationToken = default)

--- a/StepLang/Parsing/Statements/StatementType.cs
+++ b/StepLang/Parsing/Statements/StatementType.cs
@@ -14,4 +14,5 @@ public enum StatementType
     BreakStatement,
     ContinueStatement,
     IndexAssignment,
+    ImportStatement,
 }

--- a/StepLang/Tokenizing/TokenType.cs
+++ b/StepLang/Tokenizing/TokenType.cs
@@ -86,6 +86,7 @@ public static class TokenTypes
             TokenType.OpeningSquareBracket => "'['",
             TokenType.ClosingSquareBracket => "']'",
             TokenType.ColonSymbol => "':'",
+            TokenType.ImportKeyword => "'import'",
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown token type"),
         };
     }

--- a/StepLang/Tokenizing/TokenType.cs
+++ b/StepLang/Tokenizing/TokenType.cs
@@ -40,6 +40,7 @@ public enum TokenType
     OpeningSquareBracket,
     ClosingSquareBracket,
     ColonSymbol,
+    ImportKeyword,
 }
 
 public static class TokenTypes
@@ -115,6 +116,9 @@ public static class TokenTypes
                 return true;
             case "return":
                 type = TokenType.ReturnKeyword;
+                return true;
+            case "import":
+                type = TokenType.ImportKeyword;
                 return true;
         }
 


### PR DESCRIPTION
With the new `import` keyword, there are a few restrictions:

`import` statements ...

- must have the form `import <literal string>`
- must be before any other statements (i.e. at the top of a file minus comments, whitespace and new lines)
- cannot import the current file (recursive imports are prohibited)

Note: this branch is based off of #8 as it uses the tokens location to determine the relative path of imported files.