### PR TITLE
Fix string handling and use Regex.Unescape to convert escaped characters

### DIFF
--- a/StepLang.Tests/Examples/strings.step.out
+++ b/StepLang.Tests/Examples/strings.step.out
@@ -1,6 +1,7 @@
 ﻿hello world!
 h
 w
+🤷‍♂️
 6
 -1
 True

--- a/StepLang.Tests/Examples/strings.step.out
+++ b/StepLang.Tests/Examples/strings.step.out
@@ -1,7 +1,7 @@
 ﻿hello world!
 h
 w
-🤷‍♂️
+	a
 6
 -1
 True

--- a/StepLang.Tests/Tokenizing/TokenizerTest.cs
+++ b/StepLang.Tests/Tokenizing/TokenizerTest.cs
@@ -19,6 +19,20 @@ public class TokenizerTest
     }
 
     [Fact]
+    public void TestTokenizeLiteralStringWithEscapedChars()
+    {
+        const string source = "\"\\n\"";
+
+        var tokenizer = new Tokenizer();
+        tokenizer.Add(source);
+        var tokens = tokenizer.Tokenize().ToArray();
+
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.LiteralString, tokens[0].Type);
+        Assert.Equal("\n", tokens[0].Value);
+    }
+
+    [Fact]
     public void TestTokenizeLiteralNumber()
     {
         const string source = "123";

--- a/StepLang/Examples/strings.step
+++ b/StepLang/Examples/strings.step
@@ -4,6 +4,8 @@ println(foo)
 println(foo[0])
 println(foo[6])
 
+println("🤷‍♂️")
+
 println(indexOf(foo, "world"))
 println(indexOf(foo, "bar"))
 println(contains(foo, "world"))

--- a/StepLang/Examples/strings.step
+++ b/StepLang/Examples/strings.step
@@ -4,7 +4,7 @@ println(foo)
 println(foo[0])
 println(foo[6])
 
-println("🤷‍♂️")
+println("\ta")
 
 println(indexOf(foo, "world"))
 println(indexOf(foo, "bar"))

--- a/StepLang/Tokenizing/Tokenizer.cs
+++ b/StepLang/Tokenizing/Tokenizer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace StepLang.Tokenizing;
 
@@ -100,32 +101,33 @@ public class Tokenizer
 
     private Token? HandleString(char c)
     {
-        if (c is ' ')
+        if (escaped)
         {
-            tokenBuilder.Append(c);
+            var escapedChar = $"\\{c}";
+
+            tokenBuilder.Append(Regex.Unescape(escapedChar));
 
             escaped = false;
+
+            return null;
         }
-        else if (c == stringQuote)
+
+        if (c == stringQuote)
         {
-            if (escaped)
-            {
-                tokenBuilder.Append(c);
+            stringQuote = null;
+            stringStartLocation = null;
 
-                escaped = false;
-            }
-            else
-            {
-                stringQuote = null;
-                stringStartLocation = null;
-
-                return FinalizeToken(TokenType.LiteralString);
-            }
+            return FinalizeToken(TokenType.LiteralString);
         }
-        else if (c is '\\' && !escaped)
+
+        if (c is '\\')
+        {
             escaped = true;
-        else
-            tokenBuilder.Append(c);
+
+            return null;
+        }
+
+        tokenBuilder.Append(c);
 
         return null;
     }


### PR DESCRIPTION
Fixes #75.

The root cause of the issue was that only a special case for escapement was handled.
When the tokenizer encounters a `"` character, it enters a "string tokenizing mode" until it reads an unescaped `"` again.

If the tokenizer reads a `\` when in "string tokenizing mode", it ignores the `\` and enters an "escaped character mode" and appends the next character verbatim to the current token builder.

This worked fine if only the `"` is escaped. If any other character is escaped, the tokenizer only leaves the "escaped character mode" when it read a `"`.

The fix was a more general approach and an overhaul for the "escaped character mode".
It is now guaranteed to reset to the "string tokenizing mode" after an escaped character.

The escaped characters are now "unescaped" using `Regex.Unescape`, which takes care of individual escapes (like `\n` or `\t`) and hex escapes (`\xa0`).