### PR TITLE
Added `env` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Improved error reporting for when identifier usage ends early by @ricardoboss in https://github.com/ricardoboss/STEP/pull/137
 * (internal) Replaced `cmdwtf.BuildTimestampGenerator` with `Baugen` by @ricardoboss in https://github.com/ricardoboss/STEP/pull/139
 * (internal) Upgraded to xunit v3 core by @ricardoboss in https://github.com/ricardoboss/STEP/pull/140
-* Added `env` function by @ricardoboss in https://github.com/ricardoboss/STEP/pull/141
+* Added `env` function by @ricardoboss in https://github.com/ricardoboss/STEP/pull/144
 
 # v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improved error reporting for when identifier usage ends early by @ricardoboss in https://github.com/ricardoboss/STEP/pull/137
 * (internal) Replaced `cmdwtf.BuildTimestampGenerator` with `Baugen` by @ricardoboss in https://github.com/ricardoboss/STEP/pull/139
 * (internal) Upgraded to xunit v3 core by @ricardoboss in https://github.com/ricardoboss/STEP/pull/140
+* Added `env` function by @ricardoboss in https://github.com/ricardoboss/STEP/pull/141
 
 # v2.1.0
 

--- a/StepLang.Tests/Examples/env.step.out
+++ b/StepLang.Tests/Examples/env.step.out
@@ -1,0 +1,1 @@
+STEP_IS_RUNNING: true

--- a/StepLang.Wiki/Env.md
+++ b/StepLang.Wiki/Env.md
@@ -1,0 +1,21 @@
+# Description
+
+`env` is used to get or set the environment variables.
+
+# Syntax
+
+```step
+env(string key)
+env(string key, any value)
+```
+
+- `key` is the name of the environment variable to get or set.
+- `value` is the value to set the environment variable to.
+
+# Examples
+
+```step
+var path = env("PATH")
+
+env("PATH", path + ";~/.bin")
+```

--- a/StepLang/Examples/env.step
+++ b/StepLang/Examples/env.step
@@ -1,0 +1,3 @@
+env("STEP_IS_RUNNING", "true")
+
+println("STEP_IS_RUNNING: ", env("STEP_IS_RUNNING"))

--- a/StepLang/Framework/Other/EnvFunction.cs
+++ b/StepLang/Framework/Other/EnvFunction.cs
@@ -1,0 +1,47 @@
+using StepLang.Expressions;
+using StepLang.Expressions.Results;
+using StepLang.Framework.Conversion;
+using StepLang.Interpreting;
+using StepLang.Parsing.Nodes.Expressions;
+using StepLang.Tokenizing;
+
+namespace StepLang.Framework.Other;
+
+public class EnvFunction : NativeFunction
+{
+	public const string Identifier = "env";
+
+	protected override IEnumerable<NativeParameter> NativeParameters { get; } =
+	[
+		new(OnlyString, "key"),
+		new(NullableString, "newValue", LiteralExpressionNode.Null),
+	];
+
+	protected override IEnumerable<ResultType> ReturnTypes { get; } = NullableString;
+
+	public override ExpressionResult Invoke(TokenLocation callLocation, Interpreter interpreter,
+		IReadOnlyList<ExpressionNode> arguments)
+	{
+		CheckArgumentCount(callLocation, arguments, 1, 2);
+
+		var keyExpression = arguments[0].EvaluateUsing(interpreter);
+		if (keyExpression is not StringResult { Value: var key })
+		{
+			throw new InvalidArgumentTypeException(callLocation, OnlyString, keyExpression);
+		}
+
+		if (arguments.Count == 1)
+		{
+			var value = Environment.GetEnvironmentVariable(key);
+
+			return value is null ? NullResult.Instance : new StringResult(value);
+		}
+
+		var newValueExpression = arguments[1].EvaluateUsing(interpreter);
+		var stringValue = ToStringFunction.Render(newValueExpression);
+
+		Environment.SetEnvironmentVariable(key, stringValue);
+
+		return new StringResult(stringValue);
+	}
+}

--- a/StepLang/Framework/Other/EnvFunction.cs
+++ b/StepLang/Framework/Other/EnvFunction.cs
@@ -42,6 +42,6 @@ public class EnvFunction : NativeFunction
 
 		Environment.SetEnvironmentVariable(key, stringValue);
 
-		return new StringResult(stringValue);
+		return VoidResult.Instance;
 	}
 }

--- a/StepLang/Interpreting/Scope.cs
+++ b/StepLang/Interpreting/Scope.cs
@@ -95,6 +95,7 @@ public class Scope
 		CreateVariable(SeedFunction.Identifier, new SeedFunction().ToResult());
 		CreateVariable(RandomFunction.Identifier, new RandomFunction().ToResult());
 		CreateVariable(RegexMatchFunction.Identifier, new RegexMatchFunction().ToResult());
+		CreateVariable(EnvFunction.Identifier, new EnvFunction().ToResult());
 
 		// web functions
 		CreateVariable(FetchFunction.Identifier, new FetchFunction().ToResult());


### PR DESCRIPTION
General
-------

Fixes #101 by adding a new `env` function. If invoked with one argument, it retrieves the environment variable with that name and returns its value as a `string` or `null` if it didn't exist.
Invoking it with two arguments causes it to overwrite the environment variable with the second argument.


Checklist
---------

- [x] I added new/updated existing/made sure this doesn't break existing tests
- [x] I updated the CHANGELOG.md/This change doesn't need a changelog
- [x] I checked/updated any related documentation
