### PR TITLE
Add location asserts for function call tokens

### DIFF
--- a/StepLang.Tests/Tokenizing/TokenizerTest.cs
+++ b/StepLang.Tests/Tokenizing/TokenizerTest.cs
@@ -312,13 +312,23 @@ public class TokenizerTest
 		Assert.Equal(5, tokens.Count);
 		Assert.Equal(TokenType.Identifier, tokens[0].Type);
 		Assert.Equal("print", tokens[0].Value);
+		Assert.Equal(1, tokens[0].Location.Line);
+		Assert.Equal(1, tokens[0].Location.Column);
 		Assert.Equal(TokenType.OpeningParentheses, tokens[1].Type);
 		Assert.Equal("(", tokens[1].Value);
+		Assert.Equal(1, tokens[1].Location.Line);
+		Assert.Equal(6, tokens[1].Location.Column);
 		Assert.Equal(TokenType.LiteralString, tokens[2].Type);
 		Assert.Equal("\"hello\"", tokens[2].Value);
+		Assert.Equal(1, tokens[2].Location.Line);
+		Assert.Equal(7, tokens[2].Location.Column);
 		Assert.Equal(TokenType.ClosingParentheses, tokens[3].Type);
 		Assert.Equal(")", tokens[3].Value);
+		Assert.Equal(1, tokens[3].Location.Line);
+		Assert.Equal(14, tokens[3].Location.Column);
 		Assert.Equal(TokenType.EndOfFile, tokens[4].Type);
+		Assert.Equal(1, tokens[4].Location.Line);
+		Assert.Equal(source.Length + 1, tokens[4].Location.Column);
 		Assert.Empty(diagnostics);
 	}
 


### PR DESCRIPTION
## Summary
- extend `TestTokenizeFunctionCall` with line and column checks for all tokens
- run `dotnet format` to fix indentation

## Testing
- `dotnet test StepLang.Tests/StepLang.Tests.csproj -c Test -v minimal` *(fails: Test process terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68417ce0f4508333a24b845519b37e65