### PR TITLE
Fix highlighting of escaped string characters

### DIFF
--- a/StepLang.Tooling.Highlighting.Tests/HighlighterTest.cs
+++ b/StepLang.Tooling.Highlighting.Tests/HighlighterTest.cs
@@ -25,6 +25,19 @@ public class HighlighterTest
 		Assert.False(style.IsDefault);
 	}
 
+	[Fact]
+	public void TestHighlighterKeepsEscapesInStrings()
+	{
+		const string source = "string a = \"message: \\\"Hello, World!\\\"\";";
+
+		var highlighter = new Highlighter(ColorScheme.Mono);
+		var tokens = highlighter.Highlight(source).ToList();
+
+		var literal = Assert.Single(tokens, t => t.Type == TokenType.LiteralString);
+
+		Assert.Equal("\"message: \\\"Hello, World!\\\"\"", literal.Text);
+	}
+
 	public static IEnumerable<object[]> ExplicitlyStyledTokenTypes()
 	{
 		return Enum.GetValues<TokenType>()


### PR DESCRIPTION
## Summary
- ensure the highlighter re-escapes literal strings so escaped characters remain visible
- add a regression test covering escaped quotes in highlighted output

## Testing
- dotnet format --verify-no-changes
- dotnet test --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68d9179bf8088333ba0716fb2e32dcf0